### PR TITLE
refactor: consolidate Google Font imports and remove dead code

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link
-    href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap"
+    href="https://fonts.googleapis.com/css2?family=Josefin+Sans&family=Pacifico&family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&family=Raleway:wght@400;700&display=swap"
     rel="stylesheet">
   <meta name="viewport" content="width=device-width, minimum-scale=1" />
   <style>

--- a/src/components/ContactModal.jsx
+++ b/src/components/ContactModal.jsx
@@ -60,9 +60,6 @@ export default function ContactModal() {
                 </a>
               </div>
             </div>
-            {/* <div className="modal-footer border-0">
-              
-            </div> */}
           </div>
         </div>
       </div>

--- a/src/components/HolidayCarousel.jsx
+++ b/src/components/HolidayCarousel.jsx
@@ -78,7 +78,6 @@ export default function HolidayCarousel({ arr, onClick, focus }) {
               </div>
             </SwiperSlide>
           ))}
-          {/* {console.log(arr[0].type)} */}
           <SwiperSlide className="seemore">
                     <Link to={arr[0].type}>
                       <img src={seemore} width={"250px"} alt="see more" />

--- a/src/components/HomeHolidays.jsx
+++ b/src/components/HomeHolidays.jsx
@@ -175,12 +175,6 @@ const domesticHolidays = [
     description:
       'Kerala, also known as "God\'s Own Country," is a tropical paradise located in the southwestern region of India. It is known for its picturesque landscapes, serene backwaters, palm-lined beaches, and lush greenery. The state is a popular destination for tourists who are seeking a serene escape from the hustle and bustle of city life. One of the most popular destinations in Kerala is the hill station of Munnar, known for its rolling hills, tea plantations, and picturesque landscapes. Another must-visit location is the backwaters of Alleppey, where visitors can enjoy a leisurely boat ride and soak up the stunning natural beauty. Kerala is also known for its mouth-watering cuisine, which features a variety of seafood dishes, coconut-based curries, and traditional vegetarian fare. Overall, Kerala is a must-visit destination for those looking to relax and rejuvenate amidst natural beauty and traditional culture.',
   },
-  // {
-  //   id: 12,
-  //   title: "",
-  //   imageUrl: seemore,
-  //   type: "link"
-  // },
 ];
 
 const internationalHolidays = [

--- a/src/styles/AboutUs.scss
+++ b/src/styles/AboutUs.scss
@@ -1,5 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Raleway:wght@400;700&display=swap");
-
 .aboutBackground {
   background: url("../assets/images/aboutUsBgImage.jpg");
   background-attachment: fixed;

--- a/src/styles/Holiday.scss
+++ b/src/styles/Holiday.scss
@@ -1,5 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Pacifico&family=Poppins&family=Josefin+Sans&display=swap");
-
 .holidayTitle {
   position: absolute;
   font-family: "Pacifico";

--- a/src/styles/HolidayModal.scss
+++ b/src/styles/HolidayModal.scss
@@ -1,5 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Raleway:wght@400;700&display=swap");
-
 .desc {
   font-family: "Raleway";
   font-weight: 400;

--- a/src/styles/Home.scss
+++ b/src/styles/Home.scss
@@ -99,9 +99,6 @@
   @media (max-width: 768px) {
     font-size: 18px;
   }
-  @media (max-width: 576px) {
-    // font-size: 16px;
-  }
   font-size: 24px;
   font-weight: 300;
 }

--- a/src/styles/HomeCarousel.scss
+++ b/src/styles/HomeCarousel.scss
@@ -1,5 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Pacifico&family=Poppins&family=Josefin+Sans&display=swap");
-
 .homeCarousel {
   border-top-right-radius: 100px;
   border-bottom-right-radius: 100px;

--- a/src/styles/Navbar.scss
+++ b/src/styles/Navbar.scss
@@ -76,16 +76,3 @@ li:has(> a.backButton) {
   align-items: center;
 }
 
-// .notHome {
-//   opacity: 0;
-//   pointer-events: none;
-//   display: none;
-// }
-
-li:has(> a.backButton) {
-  padding: 0;
-  width: 40px;
-  height: 40px;
-  justify-content: center;
-  align-items: center;
-}

--- a/src/styles/VerticalCarousel.scss
+++ b/src/styles/VerticalCarousel.scss
@@ -1,5 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Raleway:wght@400;700&display=swap");
-
 .swiper-vertical .swiper-button-next,
 .swiper-vertical .swiper-button-prev {
 	left: 50%;

--- a/src/views/Airlines.jsx
+++ b/src/views/Airlines.jsx
@@ -1,4 +1,3 @@
-import { Link } from "react-router-dom";
 import ContactModal from "../components/ContactModal";
 import airlinesHeaderImg from "../assets/airlines/airlineHeaderImg.jpg";
 import whatsappColor from "../assets/services/whatsappColor.svg";

--- a/src/views/Cruise.jsx
+++ b/src/views/Cruise.jsx
@@ -1,4 +1,3 @@
-import { Link } from "react-router-dom";
 import cruiseHeaderImg from "../assets/images/cruise-header-img.png";
 
 import cruiseLogo1 from "../assets/cruise/cruiseLogos01.svg";

--- a/src/views/Error404.jsx
+++ b/src/views/Error404.jsx
@@ -5,7 +5,6 @@ export default function Error404() {
   return (
     <>
       <div className="error">
-        {/* <div className="headerText my-5">Error 404</div> */}
         <div className="errorContainer my-5">
           <div className="errorMessageContainer my-5">
             <div className="errorMessage1 my-5">Oops, page not found!</div>

--- a/src/views/Holylands.jsx
+++ b/src/views/Holylands.jsx
@@ -31,11 +31,6 @@ export default function Holylands() {
       imageUrl: cordobaImg,
       caption: "Cordoba, Spain",
     },
-    // {
-    //   id: 2,
-    //   imageUrl: mihrabImg,
-    //   caption: "Great Mosque of Cordoba, Spain",
-    // },
     {
       id: 2,
       imageUrl: cordobaMosqueImg,

--- a/src/views/Services.jsx
+++ b/src/views/Services.jsx
@@ -28,10 +28,6 @@ export default function Services() {
   const [focusService, setFocusService] = useState(0);
   const ref = useRef(null);
 
-  // const scrollToServices = () => {
-  //   ref.current?.scrollIntoView({ behavior: "smooth" });
-  // };
-
   const mainServices = [
     {
       id: 1,

--- a/src/views/Train.jsx
+++ b/src/views/Train.jsx
@@ -1,6 +1,5 @@
 import { EffectFade, Autoplay } from "swiper";
 import { Swiper, SwiperSlide } from "swiper/react";
-import { Link } from "react-router-dom";
 import trainHeaderImg from "../assets/images/train-header-img.png";
 import whatsappColor from "../assets/services/whatsappColor.svg";
 

--- a/src/views/Visa.jsx
+++ b/src/views/Visa.jsx
@@ -1,4 +1,3 @@
-import { Link } from "react-router-dom";
 import visaHeaderImg from "../assets/images/visa-header-img.png";
 import whatsappColor from "../assets/services/whatsappColor.svg";
 import flag1 from "../assets/flags/flag01.svg";


### PR DESCRIPTION
## Summary
- Move all Google Font imports (Pacifico, Josefin Sans, Raleway 400/700) into a single preconnected link in `index.html` alongside the existing Poppins import; remove the duplicate `@import url(...)` lines from `HomeCarousel.scss`, `Holiday.scss`, `AboutUs.scss`, `HolidayModal.scss`, and `VerticalCarousel.scss`. Eliminates five redundant font-CSS network requests that fired on different routes.
- Drop unused `Link` imports in `Airlines.jsx`, `Cruise.jsx`, `Train.jsx`, and `Visa.jsx`.
- Remove dead/leftover code: dormant `scrollToServices` ref helper in `Services.jsx`, stray `console.log` comment in `HolidayCarousel.jsx`, orphaned "seemore" placeholder in `HomeHolidays.jsx`, empty modal-footer comment in `ContactModal.jsx`, dead Error 404 header comment, duplicate Cordoba slide entry in `Holylands.jsx`, empty `@media (max-width: 576px)` block in `Home.scss`, and a duplicate `li:has(> a.backButton)` rule in `Navbar.scss`.
- The commented-out `offersArray` in `Offers.jsx` and the commented Hyderabad image imports are intentionally **left in place** as future-feature scaffolding.