### PR TITLE
fix: trigger StatCounter animation on scroll-into-view

### DIFF
--- a/src/components/StatCounter.jsx
+++ b/src/components/StatCounter.jsx
@@ -1,22 +1,44 @@
 
-import CountUp from "react-countup"
+import { useEffect, useRef, useState } from "react";
+import CountUp from "react-countup";
 
 export default function StatCounter() {
+  const ref = useRef(null);
+  const [inView, setInView] = useState(false);
+
+  useEffect(() => {
+    if (!ref.current || inView) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setInView(true);
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.2 }
+    );
+    observer.observe(ref.current);
+    return () => observer.disconnect();
+  }, [inView]);
+
+  const num = (end) =>
+    inView ? <CountUp start={0} end={end} duration={10} /> : 0;
+
   return (
-    
-    <div className="statsColumn position-absolute d-flex flex-column align-items-center">
+
+    <div ref={ref} className="statsColumn position-absolute d-flex flex-column align-items-center">
       <div className="statsRow1 d-flex justify-content-between">
         <div className="statsContainer d-flex justify-content-center align-items-center bg-white stat1">
           <div>
             {" "}
-            <span className="blue statNumber"> <CountUp start={0} end={500000} duration={10}/>+</span>
+            <span className="blue statNumber"> {num(500000)}+</span>
             <br /> <span className="statText">trips </span>
           </div>
         </div>
         <div className="statsContainer d-flex justify-content-center align-items-center bg-white stat2">
           <div>
             {" "}
-            <span className="blue statNumber"> <CountUp start={0} end={500} duration={10}/>+ </span>
+            <span className="blue statNumber"> {num(500)}+ </span>
             <br />
             <span className="statText">destinations</span>
           </div>
@@ -26,7 +48,7 @@ export default function StatCounter() {
         <div className="statsContainer d-flex justify-content-center align-items-center bg-white stat3">
           <div>
             {" "}
-            <span className="blue statNumber"> <CountUp start={0} end={45} duration={10}/>+</span>
+            <span className="blue statNumber"> {num(45)}+</span>
             <br />
             <span className="statText">years</span>
           </div>
@@ -34,7 +56,7 @@ export default function StatCounter() {
         <div className="statsContainer d-flex justify-content-center align-items-center bg-white stat4">
           <div>
             {" "}
-            <span className="blue statNumber"> <CountUp start={0} end={20} duration={10}/>+ </span>
+            <span className="blue statNumber"> {num(20)}+ </span>
             <br />
             <span className="statText"> services </span>
           </div>
@@ -44,7 +66,7 @@ export default function StatCounter() {
         <div className="statsContainer d-flex justify-content-center align-items-center bg-white stat5">
           <div>
             {" "}
-            <span className="blue statNumber"> <CountUp start={0} end={40} duration={10}/>+ </span>
+            <span className="blue statNumber"> {num(40)}+ </span>
             <br />
             <span className="statText"> awards</span>
           </div>


### PR DESCRIPTION
## Summary

- Counters in `src/components/StatCounter.jsx` used to animate on mount, off-screen behind the homepage carousel — by the time users scrolled to the stats section, the 10s count-up had already finished, so the animated effect was wasted.
- Gate the `<CountUp>` render on a single `IntersectionObserver` (threshold 0.2) attached to `.statsColumn`. While off-screen the counters render as static `0`; when the section enters the viewport, `<CountUp>` mounts and animates 0 → target. The observer disconnects on first trigger so the counters stay at their final values when the user scrolls away and back.
- Considered the built-in `enableScrollSpy` prop on `react-countup@6.4.2` first; in this app it left the counters stuck at end values on initial load and didn't reliably reset on scroll, so the explicit observer is used instead.